### PR TITLE
Fixed typo and added in names

### DIFF
--- a/index.html
+++ b/index.html
@@ -347,14 +347,15 @@
 				<h2 style="margin-top: 30px;">Company Panels</h2>
 				sheCodes organizes company panels to help members learn more about companies and get insight on different 
 				fields within computer science and technology. Previosuly, we've brought in Software Engineers from:
-				Google, Esri, BlueBeam, Target, Starbucks, ChowNow, etc. This year, company panels and company tours will be taken care by our 
-				our External Vice President: Hasti Abbasi Kenarsari. Please contact Hasti on Discord if you have any questions.
+				Google, Esri, BlueBeam, Target, Starbucks, ChowNow, etc.
+				<br>
+				This year, company panels and company tours will be taken care by our External Vice President: Hasti Abbasi Kenarsari. Please contact Hasti on Discord if you have any questions.
 			</div>
 			<div class="col-md-6 col-sm-12">
 				<h2 style="margin-top: 30px;">Social Events</h2>
 				Want to hang out and meet other members from the club? Come to our socials! Hosted by our Social Chair, Areesha Imtiaz, 
 				there will be a few social events throughout the semester. In the past we have held boba/trivia, Halloween game night,
-				Secrent Santa and many more! For me information, please contact Areesha on sheCodes Discord.
+				Secrent Santa and many more! For more information, please contact Areesha on sheCodes Discord.
 			</div>
 		</div>
 	</div>
@@ -632,8 +633,8 @@
 				<a title="LinkedIn" alt="LinkedIn" href="https://hk.linkedin.com/company/cpp-shecodes"><i class="icon fab fa-linkedin-in"></i></a>
 				<a title="Email Us" alt="Email Us" href="mailto:cpp.shecodes@gmail.com"><i class="icon fas fa-envelope"></i></a>
 			</div>
-			&copy; 2023 sheCodes.<br>
-			<small>Coded by Mohraiel Matta</small>
+			&copy; 2025 sheCodes.<br>
+			<small>Coded by Mohraiel Matta (2023). Taken care by Lesly Ibarra (2024) and Chau Nguyen (2025)</small>
 		</div>
 	</div>
 </footer>


### PR DESCRIPTION
- Fixed typo in Social Events and Company Panels.
- Added Lesly Ibarra and Chau Nguyen's names next to Mo's names and the logo at the right bottom of the page. 